### PR TITLE
fix --radius CSS variable not being taken from the themes.ts definition 

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -27,7 +27,7 @@ ${darkVars}
 }
 
 function generateRadiusCSSVars(radius: number) {
-  return `  --radius: ${radius}rem;`
+  return `  --radius: ${radius};`
 }
 
 function radiusCSSVarsStyles(radius: number) {
@@ -102,7 +102,8 @@ export function generateCSSVars(
     const lightVars = generateColorCSSVars(light)
     const darkVars = generateColorCSSVars(dark)
 
-    cssStyle += colorCSSVarsStyles(lightVars, darkVars, { radius, themeName: !onlyOne && name })
+    const themeRadius = light.radius ? light.radius : 0;
+    cssStyle += colorCSSVarsStyles(lightVars, darkVars, { radius: themeRadius, themeName: !onlyOne && name })
   }
 
   return cssStyle


### PR DESCRIPTION
### Description

You can reproduce the problem with a theme switcher, the border-radius for a button stays at --radius which is always 0.5rem before this fix. It stayed at 0.5rem no matter which theme was switched to.

### Linked Issues

None found.

### Additional context

None.
