### PR TITLE
fix: update presetShadcn return type to PresetOrFactory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Preset } from 'unocss'
+import type { PresetOrFactory } from 'unocss'
 import type { Theme } from 'unocss/preset-mini'
 
 import { generateCSSVars, generateGlobalStyles } from './generate'
@@ -12,7 +12,7 @@ export const builtinRadiuses = [0, 0.3, 0.5, 0.75, 1] as const
  * @param globals Generates global variables, like *.border-color, body.color, body.background.
  * @default true
  */
-export function presetShadcn(options: PresetShadcnOptions = {}, globals = true): Preset<Theme> {
+export function presetShadcn(options: PresetShadcnOptions = {}, globals = true): PresetOrFactory<Theme> {
   return {
     name: 'unocss-preset-shadcn',
     preflights: [


### PR DESCRIPTION
- Changed import from `Preset` to `PresetOrFactory` from 'unocss'.
- Updated the return type of `presetShadcn` function to `PresetOrFactory<Theme>`.