### PR TITLE
feat: added support for Nuxt folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ export default defineConfig({
         // the default
         /\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/,
         // include js/ts files
-        'src/**/*.{js,ts}',
+        '(components|src)/**/*.{js,ts}',
       ],
     },
   },


### PR DESCRIPTION
### Description

Adds support for ´components´ folder

### Additional context

Nuxt's folder structure doesn't use a ´/src´ folder, it can configure a 'srcDir' that replaces the base path for project files, so that shouldn't affect this change.